### PR TITLE
Async Reinvoke Support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,9 +7,11 @@ verify_ssl = true
 pytest = "*"
 twine  = "*"
 cfn-resource-provider = {editable = true,path = "."}
+boto3 = {editable = true,path = "."}
 
 [packages]
 cfn-resource-provider = {editable = true,path = "."}
+boto3 = {editable = true,path = "."}
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
This PR adds infrastructure to support:

- A wait cycle for asynchronous requests
- An automatic attempt to re-invoke the Lambda call when the Lambda nears timeout (using `get_remaining_time_in_millis` so it adapts to the Lambda's configured runtime)

I also resolved a variety of PEP8 and other IDE-highlighted issues (spacing, line length, wrong method names for `@setter`s).  If you don't override `is_ready`, it should default to the current behavior, returning immediately.  The implementation of `is_ready` is intentionally and unnecessarily complex to prompt users with best practices for use.