### PR TITLE
feat: sns envelope for sns backed custom resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ First, you inherit from the base class and specify a JSON schema which defines t
                     "type": "object",
                     "required": ["Name"],
                     "properties": {
-                        "Name": {"type": "string", 
+                        "Name": {"type": "string",
                                  "minLength": 1,
                                  "pattern": "[a-zA-Z0-9_/]+",
                                  "description": "the name of the value in the parameters store"},
-                        "Description": {"type": "string", 
+                        "Description": {"type": "string",
                                         "default": "",
                                         "description": "the description of the value in the parameter store"},
                         "Alphabet": {"type": "string",
@@ -27,7 +27,7 @@ First, you inherit from the base class and specify a JSON schema which defines t
                         "KeyAlias": {"type": "string",
                                      "default": "alias/aws/ssm",
                                      "description": "KMS key to use to encrypt the value"},
-                        "Length": {"type": "integer",  
+                        "Length": {"type": "integer",
                                    "minimum": 1, "maximum": 512,
                                    "default": 30,
                                    "description": "length of the secret"}
@@ -52,10 +52,10 @@ After that, you only need to implement the methods `create`, `update` and `delet
             except ClientError as e:
                 self.physical_resource_id = 'could-not-create'
                 self.fail(str(e))
-        
+
         def update(self):
             ....
-        
+
         def delete(self):
             ....
 
@@ -87,7 +87,7 @@ AWS CloudFormation passes all properties in  string format, eg 'true', 'false', 
         except ValueError as e:
             log.error('failed to convert property types %s', e)
 
-it is ok if you cannot convert the values: the validator will report the error for you :-) 
+it is ok if you cannot convert the values: the validator will report the error for you :-)
 
 Alternatively, you may use the `heuristic_convert_property_types` method::
 
@@ -95,3 +95,15 @@ Alternatively, you may use the `heuristic_convert_property_types` method::
         self.heuristic_convert_property_types(self.properties)
 
 it will convert all integer strings to int type, and 'true' and 'false' strings to a boolean type. Recurses through your dictionary.
+
+**Using SNS Backed custom resource provider**
+
+Next to AWS Lambda you can also use a SNS Topic to handle your custom resources. AWS calls these [Amazon Simple Notification Service-backed custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-sns.html).
+When you subscribe your AWS Lambda function to this topic the `event` structure is different than when you directly invoke the Lambda function using a custom resource.
+The payload of a Lambda function that is invoked via a SNS Topic contains 1 or more events. For this reason we provide a `SnsEnvelope` class that will process each event in the event.
+
+    def handler(request, context):
+        provider = SnsEnvelope(SampleProvider)
+        requests = provider.handle(request, context)
+
+The `SampleProvider` is the same provider that you directly would use. But by passing it into the envelope class it will be used for each event in the payload.

--- a/cfn_resource_provider/__init__.py
+++ b/cfn_resource_provider/__init__.py
@@ -1,1 +1,4 @@
 from .resource_provider  import ResourceProvider
+from .sns_envelope  import SnsEnvelope
+
+__all__ = [ResourceProvider, SnsEnvelope]

--- a/cfn_resource_provider/sns_envelope.py
+++ b/cfn_resource_provider/sns_envelope.py
@@ -1,0 +1,69 @@
+import json
+from typing import Any, List
+
+import jsonschema
+from .resource_provider import ResourceProvider
+
+SNS_SCHEMA = {
+    "type": "object",
+    "required": ["Records"],
+    "additionalProperties": True,
+    "properties": {
+        "Records": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/sns" }
+        }
+    },
+    "$defs": {
+        "sns": {
+            "type": "object",
+            "required": [ "Sns" ],
+            "properties": {
+                "Sns": {
+                    "type": "object",
+                    "required": [ "Message" ],
+                    "properties": {
+                        "Message": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+class SnsEnvelope(object):
+    """
+    When custom resources are SNS backed the CloudFormation event is wrapped within the SNS structure. To make
+    it easier to process these custom resources we created an Envelope that can unpack the SNS messages.
+    """
+
+    def __init__(self, resource_provider: ResourceProvider) -> None:
+        self.provider = resource_provider
+
+    def handle(self, event: dict, context: Any) -> List[dict]:
+        """
+        SNS payloads can hold 1 or more messages, so we need to handle each message as a custom resource.
+        """
+        if not self.__is_valid_sns_request(event):
+            raise Exception("The provided event is not compliant with the SNS schema.")
+
+        responses = []
+
+        for record in event["Records"]:
+            request = json.loads(record["Sns"]["Message"])
+
+            responses.append(self.provider().handle(request, context))
+
+        return responses
+
+
+    def __is_valid_sns_request(self, event: dict) -> bool:
+        try:
+            jsonschema.validate(event, SNS_SCHEMA)
+            return True
+        except jsonschema.ValidationError as e:
+            self.fail('invalid CloudFormation Request received: %s' % str(e.context))
+            return False

--- a/tests/test_sns_envelope.py
+++ b/tests/test_sns_envelope.py
@@ -1,0 +1,88 @@
+import json
+from typing import List
+from uuid import uuid4
+
+import pytest
+
+from cfn_resource_provider import SnsEnvelope
+from cfn_resource_provider.resource_provider import ResourceProvider
+
+
+class Request(dict):
+    def __init__(self, request_type, name, physical_resource_id=None):
+        self.update(
+            {
+                "RequestType": request_type,
+                "ResponseURL": "https://httpbin.org/put",
+                "StackId": "arn:aws:cloudformation:us-west-2:EXAMPLE/stack-name/guid",
+                "RequestId": "request-%s" % uuid4(),
+                "ResourceType": "Custom::Sample",
+                "LogicalResourceId": "MyCustomResource",
+                "ResourceProperties": {"Name": name},
+            }
+        )
+        if physical_resource_id:
+            self["PhysicalResourceId"] = physical_resource_id
+
+
+class SampleProvider(ResourceProvider):
+    def create(self) -> None:
+        self.physical_resource_id = "sample-provider-create"
+
+    def update(self) -> None:
+        self.physical_resource_id = "sample-provider-update"
+
+    def delete(self) -> None:
+        self.physical_resource_id = "sample-provider-delete"
+
+
+def sns_wrap(requests: List[Request]) -> dict:
+    messages = map(json.dumps, requests)
+    records = list(map(lambda m: {"Sns": {"Message": m}}, messages))
+
+    return {
+        "Records": records
+    }
+
+
+def test_sns_wrapped_single_request() -> None:
+    request = Request("Create", "bla", str(uuid4()))
+    provider = SnsEnvelope(SampleProvider)
+    requests = provider.handle(sns_wrap([request]), {})
+    assert len(requests) == 1
+    assert requests[0]["PhysicalResourceId"] == "sample-provider-create"
+    assert requests[0]["Status"] == "SUCCESS"
+    assert requests[0]["Reason"] == ""
+
+
+def test_sns_wrapped_multiple_requests() -> None:
+    request1 = Request("Create", "bla", str(uuid4()))
+    request2 = Request("Update", "bla", str(uuid4()))
+    request3 = Request("Delete", "bla", str(uuid4()))
+
+    provider = SnsEnvelope(SampleProvider)
+    requests = provider.handle(sns_wrap([request1, request2, request3]), {})
+    assert len(requests) == 3
+    assert requests[0]["PhysicalResourceId"] == "sample-provider-create"
+    assert requests[0]["Status"] == "SUCCESS"
+    assert requests[0]["Reason"] == ""
+
+    assert requests[1]["PhysicalResourceId"] == "sample-provider-update"
+    assert requests[1]["Status"] == "SUCCESS"
+    assert requests[1]["Reason"] == ""
+
+    assert requests[2]["PhysicalResourceId"] == "sample-provider-delete"
+    assert requests[2]["Status"] == "SUCCESS"
+    assert requests[2]["Reason"] == ""
+
+
+def test_invalid_payload() -> None:
+
+    provider = SnsEnvelope(SampleProvider)
+
+    with pytest.raises(Exception):
+        provider.handle({}, {})
+
+    with pytest.raises(Exception):
+        provider.handle({"Records": [{"Sns": {"Foo": "Bar"}}]}, {})
+


### PR DESCRIPTION
Next to AWS Lambda you can also use a SNS Topic to handle your custom resources. AWS calls these [Amazon Simple Notification Service-backed custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-sns.html). When you subscribe your AWS Lambda function to this topic the `event` structure is different than when you directly invoke the Lambda function using a custom resource. The payload of a Lambda function that is invoked via a SNS Topic contains 1 or more events. For this reason we provide a `SnsEnvelope` class that will process each event in the event.