### PR TITLE
fix: use correct typing and code block example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ it will convert all integer strings to int type, and 'true' and 'false' strings 
 
 Next to AWS Lambda you can also use a SNS Topic to handle your custom resources. AWS calls these `Amazon Simple Notification Service-backed custom resources <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-sns.html>`_.
 When you subscribe your AWS Lambda function to this topic the `event` structure is different than when you directly invoke the Lambda function using a custom resource.
-The payload of a Lambda function that is invoked via a SNS Topic contains 1 or more events. For this reason we provide a `SnsEnvelope` class that will process each event in the event.
+The payload of a Lambda function that is invoked via a SNS Topic contains 1 or more events. For this reason we provide a `SnsEnvelope` class that will process each event in the event::
 
     def handler(request, context):
         provider = SnsEnvelope(SampleProvider)

--- a/cfn_resource_provider/sns_envelope.py
+++ b/cfn_resource_provider/sns_envelope.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List
+from typing import Any, List, Type
 
 import jsonschema
 from .resource_provider import ResourceProvider
@@ -40,7 +40,7 @@ class SnsEnvelope(object):
     it easier to process these custom resources we created an Envelope that can unpack the SNS messages.
     """
 
-    def __init__(self, resource_provider: ResourceProvider) -> None:
+    def __init__(self, resource_provider: Type[ResourceProvider]) -> None:
         self.provider = resource_provider
 
     def handle(self, event: dict, context: Any) -> List[dict]:


### PR DESCRIPTION
During the usage of my `SnsEnvelope` implementation I noticed that the typing was not correctly set. This causes the IDE to complain in some cases. By providing the correct type we avoid this.

Also the codeblock was not formatted correctly so I included this in the same PR.